### PR TITLE
Revert "kuntao: Default userdata filesystem to ext4" back to F2FS to install Android10

### DIFF
--- a/twrp/recovery/root/etc/twrp.fstab
+++ b/twrp/recovery/root/etc/twrp.fstab
@@ -2,7 +2,7 @@
 /system_image    emmc              /dev/block/bootdevice/by-name/system
 /vendor          ext4              /dev/block/bootdevice/by-name/preload
 /vendor_image    emmc              /dev/block/bootdevice/by-name/preload
-/data            ext4              /dev/block/bootdevice/by-name/userdata   flags=encryptable=footer;length=-16384
+/data            f2fs              /dev/block/bootdevice/by-name/userdata   flags=encryptable=footer;length=-16384
 /cache           ext4              /dev/block/bootdevice/by-name/cache
 /persist         ext4              /dev/block/bootdevice/by-name/persist    flags=backup=1;display="Persist"
 /boot            emmc              /dev/block/bootdevice/by-name/boot


### PR DESCRIPTION
Couldn't install android10 on kuntao till I reformated data partition to f2fs. I hope thats the correct way to handle this. There are already discussions on [xda](https://forum.xda-developers.com/showpost.php?p=82972211&postcount=558) 

This reverts commit d89a9d2e9dd81adb9bec40a6d7a77c0ab74c9989.