### PR TITLE
Set ISO_DEP_MAX_TRANSCEIVE to 0xFEFF

### DIFF
--- a/configs/nfc/libnfc-nci.conf
+++ b/configs/nfc/libnfc-nci.conf
@@ -114,3 +114,7 @@ NFA_HCI_STATIC_PIPE_ID_F5=0x72
 #  byte[7] NCI_DISCOVERY_TYPE_POLL_B_PRIME
 #  byte[8] NCI_DISCOVERY_TYPE_LISTEN_B_PRIME
 NFA_PROPRIETARY_CFG={05:FF:FF:06:81:80:77:FF:FF}
+
+###############################################################################
+# Extended APDU length for ISO_DEP
+ISO_DEP_MAX_TRANSCEIVE=0xFEFF


### PR DESCRIPTION
Hello. Big fan of the project, thank you so much for the time and effort!

I've observed problems with decryption using OpenKeychain, exactly as described here: https://github.com/open-keychain/open-keychain/issues/2501

Based [this comment](https://github.com/open-keychain/open-keychain/issues/2501#issuecomment-565153418) and other libnfc conf files I found on the internet I've updated the correct file for encryption with PGP key on Yubikey to work on kuntao.

The same config lines in another device's LineageOS code for reference: https://github.com/LineageOS/android_device_bq_msm8953-common/blob/e7c08e600ba3197e0d087e7fe3a6278823317ad0/configs/nfc/libnfc-nxp.conf#L659-L661

Manually changed `/system/system/product/etc/libnfc-nci.conf` on my kuntao and verified it's working.